### PR TITLE
Add option `disable_cmd_history` to disable Vim command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,16 @@ list of supported command modifiers, see `:help fzy-commands-split`.
 Options can be passed to fzy through the dictionary `g:fzy`. The following
 entries are supported:
 
-| Entry            | Description                                                                  | Default                            |
-| ---------------- | ---------------------------------------------------------------------------- | ---------------------------------- |
-| `lines`          | Specify how many lines of results to show. This sets fzy's `--lines` option. | `10`                               |
-| `prompt`         | Set the fzy input prompt.                                                    | `'▶ '`                             |
-| `showinfo`       | If true, fzy is invoked with the `--show-info` option.                       | `v:false`                          |
-| `term_highlight` | Highlight group for the terminal window.                                     | `'Terminal'`                       |
-| `popupwin`       | Display fzy in a popup terminal.                                             | `v:false`                          |
-| `popup`          | Popup window options (dictionary).                                           | [see below](#popup-window-options) |
-| `findcmd`        | File-search command (string).                                                | [see below](#find-command)         |
-| `grepcmd`        | Grep-search command.                                                         | `&grepprg`                         |
-| `grepformat`     | Format string for parsing the selected grep-output line.                     | `&grepformat`                      |
+| Entry            | Description                                              | Default                            |
+| `prompt`         | Set the fzy input prompt.                                | `'▶ '`                             |
+| `showinfo`       | If true, fzy is invoked with the `--show-info` option.   | `v:false`                          |
+| `term_highlight` | Highlight group for the terminal window.                 | `'Terminal'`                       |
+| `popupwin`       | Display fzy in a popup terminal.                         | `v:false`                          |
+| `popup`          | Popup window options (dictionary).                       | [see below](#popup-window-options) |
+| `findcmd`        | File-search command (string).                            | [see below](#find-command)         |
+| `grepcmd`        | Grep-search command.                                     | `&grepprg`                         |
+| `grepformat`     | Format string for parsing the selected grep-output line. | `&grepformat`                      |
+| `histadd`        | If true, add edit command to history.                    | `v:false`                          |
 
 When `popupwin` is set to `v:false`, the terminal window is opened at the bottom
 of the screen and will occupy the full width of the Vim window.
@@ -113,6 +112,7 @@ g:fzy = {
     findcmd: 'fd --type f',
     grepcmd: 'grep -Hn',
     grepformat: '%f:%l:%m',
+    histadd: true,
     prompt: '>>> ',
     showinfo: true,
     lines: 15,

--- a/autoload/fzy.vim
+++ b/autoload/fzy.vim
@@ -24,6 +24,12 @@ def Error(msg: string)
     echohl ErrorMsg | echomsg msg | echohl None
 enddef
 
+def Update_cmd_history(cmd: string)
+    if get(get(g:, 'fzy', {}), 'histadd', false)
+        histadd('cmd', cmd)
+    endif
+enddef
+
 def Tryexe(cmd: string)
     try
         execute cmd
@@ -118,18 +124,18 @@ enddef
 def Find_cb(dir: string, vim_cmd: string, choice: string)
     var fpath: string = fnamemodify(dir, ':p:s?/$??') .. '/' .. choice
     fpath = fpath->resolve()->fnamemodify(':.')->fnameescape()
-    histadd('cmd', $'{vim_cmd} {fpath}')
+    Update_cmd_history($'{vim_cmd} {fpath}')
     Tryexe($'{vim_cmd} {fpath}')
 enddef
 
 def Open_file_cb(vim_cmd: string, choice: string)
     const fname: string = fnameescape(choice)
-    histadd('cmd', $'{vim_cmd} {fname}')
+    Update_cmd_history($'{vim_cmd} {fname}')
     Tryexe($'{vim_cmd} {fname}')
 enddef
 
 def Open_tag_cb(vim_cmd: string, choice: string)
-    histadd('cmd', vim_cmd .. ' ' .. choice)
+    Update_cmd_history(vim_cmd .. ' ' .. choice)
     Tryexe(vim_cmd .. ' ' .. escape(choice, '"'))
 enddef
 
@@ -149,7 +155,7 @@ def Grep_cb(efm: string, vim_cmd: string, choice: string)
     endif
     setbufvar(items[0].bufnr, '&buflisted', 1)
     const cmd: string = $'{vim_cmd} {items[0].bufnr} | call cursor({items[0].lnum}, {items[0].col})'
-    histadd('cmd', cmd)
+    Update_cmd_history(cmd)
     Tryexe(cmd)
 enddef
 
@@ -172,6 +178,7 @@ export def Start(items: any, On_select_cb: func, options: dict<any> = {}): numbe
         lines: 10,
         showinfo: 0,
         popup: {},
+        histadd: false,
         statusline: 'fzy-term'
     }, 'keep')
 


### PR DESCRIPTION
Hi @bfrg,


Follows up this issue https://github.com/bfrg/vim-fzy/issues/5.
Add option to disable VIM command history, please help me to review this PR.

Please let me know if I need to update something, thanks.

